### PR TITLE
Removed dependencies from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(giskard_boxy)
 
-find_package(catkin REQUIRED COMPONENTS
-  giskard_ros
-  iai_boxy_sim)
+find_package(catkin REQUIRED)
 
 catkin_package()


### PR DESCRIPTION
catkin_make complains about giskard_ros missing at compile time. I suspect that the problem is that in package.xml the dependency is declared as run_depend (and not build_depend) so it is not available at compile time for cmake. As CMake is not actually used in this package, I suggest to get rid of dependencies in cmakelists. Alternatively, one could declare giskard_ros as build_depend.